### PR TITLE
Fix typo in `cacert` help message

### DIFF
--- a/keyser
+++ b/keyser
@@ -134,7 +134,7 @@ Example
     -c FR \
     -d local,localhost
     -e no-reply@adaltas.com \
-    -i 127.0.0.1
+    -a 127.0.0.1
     -l Paris \
     -o Adaltas \
     adaltas.com


### PR DESCRIPTION
Fix a typo in the `cacert` command help message.