### PR TITLE
`utils_decrypt__no_exists` should succeed when command fails

### DIFF
--- a/test/utils_decrypt__no_exists.sh
+++ b/test/utils_decrypt__no_exists.sh
@@ -7,7 +7,8 @@ function test {
   KEYSER_VAULT_DIR='../tmp/utils_decrypt__no_exists'
   KEYSER_GPG_PASSPHRASE=secret
   mkdir -p $KEYSER_VAULT_DIR
-  res=$(utils_decrypt $KEYSER_VAULT_DIR/does_not_exists $KEYSER_VAULT_DIR/target) || return 1
+  res=$(utils_decrypt $KEYSER_VAULT_DIR/does_not_exists $KEYSER_VAULT_DIR/target)
+  [[ $? == 1 ]] || return 1
   echo "$res" | grep 'No such file to decrypt.' > /dev/null || return 1
 }
 


### PR DESCRIPTION
Capture stdout before checking exit status so the test can assert the error code.