### PR TITLE
Report test failures instead of exiting early

### DIFF
--- a/test/all.sh
+++ b/test/all.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
-set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
+
+failed=0
 
 for test in *.sh; do
   if [[ $test != "all.sh" ]]; then
     printf "%-50s" "$test"
     # shellcheck source=/dev/null
     . "$test"
-    (test && echo 'OK') || (echo 'KO' && exit 1)
+    if test; then
+      echo 'OK'
+    else
+      echo 'KO'
+      failed=$((failed + 1))
+    fi
   fi
 done
+
+if [[ $failed -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Test should continue to run even if one fails.