### PR TITLE
`utils_encrypt` error handling

### DIFF
--- a/keyser
+++ b/keyser
@@ -1042,7 +1042,7 @@ utils_encrypt(){
     if [[ ! -f "$source" ]]; then echo 'No such file to encrypt.'; exit 1; fi
     if [[ -f "$target" ]]; then rm "$target"; fi
     gpg --batch --passphrase "$KEYSER_GPG_PASSPHRASE" --output "$target" --symmetric "$source" \
-    || echo 'GPG command failed' && return 1
+    || { echo 'GPG command failed'; return 1; }
     echo "$target"
   fi
 }

--- a/test/utils_decrypt.sh
+++ b/test/utils_decrypt.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+. ../keyser
+
+function test {
+  KEYSER_VAULT_DIR='../tmp/utils_decrypt'
+  KEYSER_GPG_PASSPHRASE=secret
+  rm -rf $KEYSER_VAULT_DIR
+  mkdir -p $KEYSER_VAULT_DIR
+  echo "test content" > $KEYSER_VAULT_DIR/test.txt
+  utils_encrypt $KEYSER_VAULT_DIR/test.txt $KEYSER_VAULT_DIR/test.txt.gpg > /dev/null
+  res=$(utils_decrypt $KEYSER_VAULT_DIR/test.txt.gpg $KEYSER_VAULT_DIR/decrypted.txt) || return 1
+  [[ -f $KEYSER_VAULT_DIR/decrypted.txt ]] || return 1
+  [[ "$(cat $KEYSER_VAULT_DIR/decrypted.txt)" == "test content" ]] || return 1
+  echo "$res" | grep 'decrypted.txt' > /dev/null || return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
+  echo -n "$0: "
+  test && echo 'OK' || echo 'KO'
+fi

--- a/test/utils_encrypt.sh
+++ b/test/utils_encrypt.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+. ../keyser
+
+function test {
+  KEYSER_VAULT_DIR='../tmp/utils_encrypt'
+  KEYSER_GPG_PASSPHRASE=secret
+  rm -rf $KEYSER_VAULT_DIR
+  mkdir -p $KEYSER_VAULT_DIR
+  echo "test content" > $KEYSER_VAULT_DIR/test.txt
+  res=$(utils_encrypt $KEYSER_VAULT_DIR/test.txt $KEYSER_VAULT_DIR/test.txt.gpg) || return 1
+  [[ -f $KEYSER_VAULT_DIR/test.txt.gpg ]] || return 1
+  echo "$res" | grep 'test.txt.gpg' > /dev/null || return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
+  echo -n "$0: "
+  test && echo 'OK' || echo 'KO'
+fi


### PR DESCRIPTION
```sh
gpg ... || echo 'GPG command failed' && return 1
```

Was parsed as:

```sh
(gpg ... || echo 'GPG command failed') && return 1
```

Which causes the code to fail everytime.